### PR TITLE
test(egg): intentionally break go build to test auto-remediation

### DIFF
--- a/protoc-gen-grpc-gateway/internal/gengateway/generator.go
+++ b/protoc-gen-grpc-gateway/internal/gengateway/generator.go
@@ -1,5 +1,5 @@
 package gengateway
-This is intentionally broken plain text that will cause a compile error.
+// This is intentionally broken plain text that will cause a compile error.
 
 import (
 	"errors"

--- a/protoc-gen-grpc-gateway/internal/gengateway/generator.go
+++ b/protoc-gen-grpc-gateway/internal/gengateway/generator.go
@@ -1,4 +1,5 @@
 package gengateway
+This is intentionally broken plain text that will cause a compile error.
 
 import (
 	"errors"

--- a/protoc-gen-grpc-gateway/main.go
+++ b/protoc-gen-grpc-gateway/main.go
@@ -8,7 +8,7 @@
 //
 // See README.md for more details.
 package main
-This is intentionally broken plain text that will cause a compile error.
+// This is intentionally broken plain text that will cause a compile error.
 
 import (
 	"flag"

--- a/protoc-gen-grpc-gateway/main.go
+++ b/protoc-gen-grpc-gateway/main.go
@@ -8,6 +8,7 @@
 //
 // See README.md for more details.
 package main
+This is intentionally broken plain text that will cause a compile error.
 
 import (
 	"flag"


### PR DESCRIPTION
This PR is part of an automated test of Egg's post-publish CI remediation hooks.

It intentionally injects invalid plain text into Go source files, which breaks `go build`.
After the PR is published, Egg will automatically fetch the failing CI logs via the `gh` CLI
and ask Codex to fix the code by incorporating the plain text into a doc comment.

[_Hatched by a Sourcegraph egg._](https://egg.sgdev.dev/egg/publish/robert/break-and-recover-go-build-x7k2)